### PR TITLE
Copy provider source directory to base working directory for local fixture access during tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 // implemented by direct configuration.
 type Config struct {
 	PluginName         string
+	SourceDir          string
 	TerraformExec      string
 	CurrentPluginExec  string
 	PreviousPluginExec string
@@ -18,7 +19,7 @@ type Config struct {
 
 // DiscoverConfig uses environment variables and other means to automatically
 // discover a reasonable test helper configuration.
-func DiscoverConfig(pluginName string) (*Config, error) {
+func DiscoverConfig(pluginName string, sourceDir string) (*Config, error) {
 	tfExec := FindTerraform()
 	if tfExec == "" {
 		return nil, fmt.Errorf("unable to find 'terraform' executable for testing; either place it in PATH or set TFTEST_TERRAFORM explicitly to a direct executable path")
@@ -34,6 +35,7 @@ func DiscoverConfig(pluginName string) (*Config, error) {
 
 	return &Config{
 		PluginName:         pluginName,
+		SourceDir:          sourceDir,
 		TerraformExec:      tfExec,
 		CurrentPluginExec:  os.Args[0],
 		PreviousPluginExec: os.Getenv("TFTEST_PREVIOUS_EXEC"),

--- a/util.go
+++ b/util.go
@@ -1,0 +1,70 @@
+package tftest
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func copyFile(src string, dest string) (err error) {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer srcFile.Close()
+
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err == nil {
+		srcInfo, err := os.Stat(src)
+		if err != nil {
+			err = os.Chmod(dest, srcInfo.Mode())
+		}
+
+	}
+
+	return
+}
+
+// CopyDir is a simplistic function for recursively copying a directory to a new path.
+// It is intended only for limited internal use and does not cover all edge cases.
+func copyDir(srcDir string, destDir string) (err error) {
+	srcInfo, err := os.Stat(srcDir)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(destDir, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	directory, _ := os.Open(srcDir)
+	objects, err := directory.Readdir(-1)
+
+	for _, obj := range objects {
+		srcPath := filepath.Join(srcDir, obj.Name())
+		destPath := filepath.Join(destDir, obj.Name())
+
+		if obj.IsDir() {
+			err = copyDir(srcPath, destPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = copyFile(srcPath, destPath)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+	return
+}

--- a/working_dir.go
+++ b/working_dir.go
@@ -14,8 +14,12 @@ import (
 // NewWorkingDir or RequireNewWorkingDir on its package's singleton
 // tftest.Helper.
 type WorkingDir struct {
-	h         *Helper
-	baseDir   string
+	h *Helper
+
+	// baseDir is the root of the working directory tree
+	baseDir string
+
+	// configDir contains the singular config file generated for each test
 	configDir string
 }
 
@@ -39,11 +43,12 @@ func (wd *WorkingDir) SetConfig(cfg string) error {
 	if err != nil {
 		return err
 	}
-	configFilename := filepath.Join(configDir, "test.tf")
+	configFilename := filepath.Join(configDir, "terraform_plugin_test.tf")
 	err = ioutil.WriteFile(configFilename, []byte(cfg), 0700)
 	if err != nil {
 		return err
 	}
+
 	wd.configDir = configDir
 
 	// Changing configuration invalidates any saved plan.


### PR DESCRIPTION
Raising this as a PR for some feedback on whether this is the right abstraction. @appilon I'd like your review but can't add you as a reviewer.
Please see the "Tests making use of the local filesystem" section of TF-183 for more context.

Note that this PR changes the signature of the public `AutoInitProviderHelper` function.

---

Provider acceptance tests sometimes read test fixture files located variously in the provider source code directory tree, using `file()`. For example:

```
resource "aws_iot_certificate" "cert" {
  csr    = "${file("test-fixtures/iot-csr.pem")}"
  active = true
}
```

 Since there is not yet a naming convention for these fixture files, this PR allows consumers of this library to pass in the entire source directory.
The contents of the source directory are copied into the base directory when a new `WorkingDir` is created.

Proposed usage in the SDK: https://github.com/hashicorp/terraform-plugin-sdk/pull/262/commits/c6ed429531373ab7ae954a0bb451d3e3447e7d16

Note that the directory copied will be that containing `provider_test.go`, which is generally a subdirectory (e.g. `terraform-provider-aws/aws/`), not the root of the provider source code tree. This means that file paths involving parent directory traversal will **not** work. Such usage seems to be rare: the only example I have found in terraform-providers is https://github.com/terraform-providers/terraform-provider-bigip/blob/master/bigip/resource_bigip_as3_test.go#L26.

