### PR TITLE
Avoid implicit refreshing

### DIFF
--- a/working_dir.go
+++ b/working_dir.go
@@ -169,7 +169,7 @@ func (wd *WorkingDir) planFilename() string {
 // CreatePlan runs "terraform plan" to create a saved plan file, which if successful
 // will then be used for the next call to Apply.
 func (wd *WorkingDir) CreatePlan() error {
-	args := []string{"plan"}
+	args := []string{"plan", "-refresh=false"}
 	args = append(args, wd.baseArgs...)
 	args = append(args, "-out=tfplan", wd.configDir)
 	return wd.runTerraform(args...)
@@ -190,7 +190,7 @@ func (wd *WorkingDir) RequireCreatePlan(t TestControl) {
 // this will apply the saved plan. Otherwise, it will implicitly create a new
 // plan and apply it.
 func (wd *WorkingDir) Apply() error {
-	args := []string{"apply"}
+	args := []string{"apply", "-refresh=false"}
 	args = append(args, wd.baseArgs...)
 
 	if wd.HasSavedPlan() {
@@ -219,7 +219,7 @@ func (wd *WorkingDir) RequireApply(t TestControl) {
 // If destroy fails then remote objects might still exist, and continue to
 // exist after a particular test is concluded.
 func (wd *WorkingDir) Destroy() error {
-	args := []string{"destroy"}
+	args := []string{"destroy", "-refresh=false"}
 	args = append(args, wd.baseArgs...)
 
 	args = append(args, "-auto-approve", wd.configDir)


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-plugin-test/pull/6

--- 
This aligns the new driver with the old one more and allows certain tests to pass, e.g. this one in Packet would never pass because of failing refresh on destroy:

```
--- FAIL: TestAccPacketOperatingSystem_NotFound (2.45s)
    testing_new.go:35: WARNING: destroy failed, so remote objects may still exist and be subject to billing
    testing_new.go:35: failed to destroy: terraform failed: exit status 1
        
        stderr:
         [31m
         [1m [31mError:  [0m [0m [1mThere are no operating systems that match the search criteria [0m
        
         [0m  on config452693439/terraform_plugin_test.tf line 2, in data "packet_operating_system" "example":
           2: 	data "packet_operating_system" "example"  [4m{ [0m
         [0m
         [0m [0m
        
FAIL
```