### PR TITLE
Pass config path to refresh command

### DIFF
--- a/working_dir.go
+++ b/working_dir.go
@@ -334,6 +334,8 @@ func (wd *WorkingDir) RequireImport(t TestControl, resource, id string) {
 func (wd *WorkingDir) Refresh() error {
 	args := []string{"refresh"}
 	args = append(args, wd.baseArgs...)
+	args = append(args, "-state="+filepath.Join(wd.baseDir, "terraform.tfstate"))
+	args = append(args, wd.configDir)
 	return wd.runTerraform(args...)
 }
 


### PR DESCRIPTION
This is to prevent data sources from disappearing as described in https://github.com/hashicorp/terraform/issues/24022
