### PR TITLE
Multi-provider testing

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -217,8 +217,14 @@ func (h *Helper) NewWorkingDir() (*WorkingDir, error) {
 		return nil, err
 	}
 
-	// copy the provider source files into the base directory
+	// symlink the provider source files into the base directory
 	err = symlinkDir(h.sourceDir, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// symlink the provider binaries into the base directory
+	err = symlinkDir(h.thisPluginDir, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/terraform.go
+++ b/terraform.go
@@ -89,6 +89,7 @@ func getTerraformEnv() []string {
 	}
 
 	env = append(env, "TF_DISABLE_PLUGIN_TLS=1")
+	env = append(env, "TF_SKIP_PROVIDER_VERIFY=1")
 
 	// FIXME: Ideally in testing.Verbose mode we'd turn on Terraform DEBUG
 	// logging, perhaps redirected to a separate fd other than stderr to avoid

--- a/working_dir.go
+++ b/working_dir.go
@@ -116,7 +116,6 @@ func (wd *WorkingDir) RequireClearPlan(t TestControl) {
 func (wd *WorkingDir) init(pluginDir string) error {
 	args := []string{"init"}
 	args = append(args, wd.baseArgs...)
-	args = append(args, "-plugin-dir="+pluginDir, wd.configDir)
 	return wd.runTerraform(args...)
 }
 


### PR DESCRIPTION
Some Terraform provider acceptance tests make use of other Terraform providers. We will refer to these as _multi-provider acceptance tests_, in which a _primary provider_ under test uses resources from _auxiliary providers_. 

For example, consider the following (abbreviated) test configuration string in [resource_kubernetes_persistent_volume_test.go](https://github.com/terraform-providers/terraform-provider-kubernetes/blob/master/kubernetes/resource_kubernetes_persistent_volume_test.go) (terraform-provider-kubernetes):
```
resource "kubernetes_persistent_volume" "test" {
  spec {
    persistent_volume_source {
      aws_elastic_block_store {
        volume_id = "${aws_ebs_volume.test.id}"
      }
    }
  }
}
resource "aws_ebs_volume" "test" {
  size = 10
}
```
Here, the primary `kubernetes` provider uses a resource from the auxiliary `google` provider.

The binary test driver will first attempt to load auxiliary provider binaries stored in `terraform.d` in the provider source code repository itself. If the required provider binary is not found there, it will fall back to the Terraform CLI’s plugin discovery mechanism.