### PR TITLE
symlink only directories when linking provider source files

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -218,7 +218,7 @@ func (h *Helper) NewWorkingDir() (*WorkingDir, error) {
 	}
 
 	// symlink the provider source files into the base directory
-	err = symlinkDir(h.sourceDir, dir)
+	err = symlinkDirectoriesOnly(h.sourceDir, dir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Symlinking every source file recursively leads to a huge number of file descriptors being allocated in large provider parallel test runs.

This PR modifies the test setup functionality so only directories are linked, non-recursively. 

This change assumes that acceptance tests do not use test fixture files residing adjacent to package source files - they should be in a separate directory, e.g. `./aws/test-fixtures/fixture.txt`, not `./aws/fixture.txt`. This assumption seems to be true for all the providers I've checked.