### PR TITLE
add helper.GetPluginName()

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -196,6 +196,11 @@ func symlinkAuxiliaryProviders(pluginDir string) error {
 	return nil
 }
 
+// GetPluginName returns the configured plugin name.
+func (h *Helper) GetPluginName() string {
+	return h.pluginName
+}
+
 // Close cleans up temporary files and directories created to support this
 // helper, returning an error if any of the cleanup fails.
 //


### PR DESCRIPTION
Add a function to return the `pluginName` set on the `Helper` struct. This is needed for features such as cty-in-tests and Delve debugging, which require access to the provider during the test.

Note that the format of the provider name will be `terraform-provider-NAME`, as set in https://github.com/hashicorp/terraform-plugin-test/blob/master/helper.go#L27.