### PR TITLE
Add SetInputVars and RequireSetInputVars to WorkingDir

### DIFF
--- a/working_dir.go
+++ b/working_dir.go
@@ -92,6 +92,26 @@ func (wd *WorkingDir) RequireSetConfig(t TestControl, cfg string) {
 	}
 }
 
+// SetInputVars creates a terraform.tfvars file in the working directory.
+func (wd *WorkingDir) SetInputVars(tfvars string) error {
+	tfvarsFilename := filepath.Join(wd.baseDir, "terraform.tfvars")
+	err := ioutil.WriteFile(tfvarsFilename, []byte(tfvars), 0700)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RequireSetInputVars is a variant of SetInputVars that will fail the test via the
+// given TestControl if the terraform.tfvars file cannot be created.
+func (wd *WorkingDir) RequireSetInputVars(t TestControl, tfvars string) {
+	t.Helper()
+	if err := wd.SetInputVars(tfvars); err != nil {
+		t := testingT{t}
+		t.Fatalf("failed to set vars: %s", err)
+	}
+}
+
 // ClearState deletes any Terraform state present in the working directory.
 //
 // Any remote objects tracked by the state are not destroyed first, so this

--- a/working_dir.go
+++ b/working_dir.go
@@ -1,6 +1,7 @@
 package tftest
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -92,10 +93,14 @@ func (wd *WorkingDir) RequireSetConfig(t TestControl, cfg string) {
 	}
 }
 
-// SetInputVars creates a terraform.tfvars file in the working directory.
-func (wd *WorkingDir) SetInputVars(tfvars string) error {
-	tfvarsFilename := filepath.Join(wd.baseDir, "terraform.tfvars")
-	err := ioutil.WriteFile(tfvarsFilename, []byte(tfvars), 0700)
+// SetInputVars creates a inputs.auto.tfvars.json file in the working directory.
+func (wd *WorkingDir) SetInputVars(tfvars map[string]interface{}) error {
+	tfvarsFilename := filepath.Join(wd.baseDir, "inputs.auto.tfvars.json")
+	b, err := json.Marshal(tfvars)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(tfvarsFilename, b, 0700)
 	if err != nil {
 		return err
 	}
@@ -103,8 +108,8 @@ func (wd *WorkingDir) SetInputVars(tfvars string) error {
 }
 
 // RequireSetInputVars is a variant of SetInputVars that will fail the test via the
-// given TestControl if the terraform.tfvars file cannot be created.
-func (wd *WorkingDir) RequireSetInputVars(t TestControl, tfvars string) {
+// given TestControl if the inputs.auto.tfvars.json file cannot be created.
+func (wd *WorkingDir) RequireSetInputVars(t TestControl, tfvars map[string]interface{}) {
 	t.Helper()
 	if err := wd.SetInputVars(tfvars); err != nil {
 		t := testingT{t}


### PR DESCRIPTION
👋 

## Description

This PR adds the ability to set input variables by creating a ~`terraform.tfvars`~ `inputs.auto.tfvars.json` file in the working directory.

## Context

I'm working on the new Kubernetes provider, which is a crazy wild west provider that doesn't use the existing terraform plugin SDK so we are using this helper package directly in the acceptance tests. 

One of things we'd like to do is have the terraform configurations for the acceptance tests be in their own files so that we can easily run them by hand, without having to hack out Go formatting directives. The way we're doing this is by using terraform's own input variables syntax in the test configurations, and supplying them when we set up the test. This way all we need to do is supply variables if we run them by hand. It also makes the test configurations more legible for people looking for runnable examples.

At the moment I have a hack in the test code that creates `variable` blocks with defaults at the top of whatever is created with `RequireSetConfig` but it would be nice if the helper could do this for us.

## Discussion

Not sure if this is even the right abstraction - we could also do this as an additional parameter to SetConfig, or by exposing a way to supply `-var` flags to the baseArgs array instead.