### PR TITLE
Refer to config directories using relative paths.

### DIFF
--- a/working_dir.go
+++ b/working_dir.go
@@ -257,15 +257,7 @@ func (wd *WorkingDir) Destroy() error {
 	args := []string{"destroy", "-refresh=false"}
 	args = append(args, wd.baseArgs...)
 
-	// we need to use a relative config dir here or we get an
-	// error about Terraform not having any configuration. See
-	// https://github.com/hashicorp/terraform-plugin-sdk/issues/495
-	// for more info.
-	configDir, err := wd.relativeConfigDir()
-	if err != nil {
-		return err
-	}
-	args = append(args, "-auto-approve", configDir)
+	args = append(args, "-auto-approve", wd.configDir)
 	return wd.runTerraform(args...)
 }
 

--- a/working_dir.go
+++ b/working_dir.go
@@ -53,6 +53,14 @@ func (wd *WorkingDir) GetHelper() *Helper {
 	return wd.h
 }
 
+func (wd *WorkingDir) relativeConfigDir() (string, error) {
+	relPath, err := filepath.Rel(wd.baseDir, wd.configDir)
+	if err != nil {
+		return "", fmt.Errorf("Error determining relative path of configuration directory: %w", err)
+	}
+	return relPath, nil
+}
+
 // SetConfig sets a new configuration for the working directory.
 //
 // This must be called at least once before any call to Init, Plan, Apply, or
@@ -215,8 +223,16 @@ func (wd *WorkingDir) Apply() error {
 	if wd.HasSavedPlan() {
 		args = append(args, "tfplan")
 	} else {
+		// we need to use a relative config dir here or we get an
+		// error about Terraform not having any configuration. See
+		// https://github.com/hashicorp/terraform-plugin-sdk/issues/495
+		// for more info.
+		configDir, err := wd.relativeConfigDir()
+		if err != nil {
+			return err
+		}
 		args = append(args, "-auto-approve")
-		args = append(args, wd.configDir)
+		args = append(args, configDir)
 	}
 
 	return wd.runTerraform(args...)
@@ -241,7 +257,15 @@ func (wd *WorkingDir) Destroy() error {
 	args := []string{"destroy", "-refresh=false"}
 	args = append(args, wd.baseArgs...)
 
-	args = append(args, "-auto-approve", wd.configDir)
+	// we need to use a relative config dir here or we get an
+	// error about Terraform not having any configuration. See
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/495
+	// for more info.
+	configDir, err := wd.relativeConfigDir()
+	if err != nil {
+		return err
+	}
+	args = append(args, "-auto-approve", configDir)
 	return wd.runTerraform(args...)
 }
 


### PR DESCRIPTION
It turns out that hashicorp/terraform#25233 means that referring to
configuration files by absolute paths means that this library doesn't
work for Windows users using Terraform versions before 0.13.0-beta2. By
forcing relative paths, we can sidestep this bug, and make this work
across a wider range of Terraform versions on Windows.

See hashicorp/terraform-plugin-sdk#495.