### PR TITLE
Remove visibility to plugin under test

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/hashicorp/terraform-exec/tfinstall"
 )
@@ -14,17 +13,15 @@ import (
 // DiscoverConfig, but this is exposed so that more complex scenarios can be
 // implemented by direct configuration.
 type Config struct {
-	PluginName         string
 	SourceDir          string
 	TerraformExec      string
 	execTempDir        string
-	CurrentPluginExec  string
 	PreviousPluginExec string
 }
 
 // DiscoverConfig uses environment variables and other means to automatically
 // discover a reasonable test helper configuration.
-func DiscoverConfig(pluginName string, sourceDir string) (*Config, error) {
+func DiscoverConfig(sourceDir string) (*Config, error) {
 	tfVersion := os.Getenv("TF_ACC_TERRAFORM_VERSION")
 	tfPath := os.Getenv("TF_ACC_TERRAFORM_PATH")
 
@@ -48,26 +45,9 @@ func DiscoverConfig(pluginName string, sourceDir string) (*Config, error) {
 		return nil, err
 	}
 
-	prevExec := os.Getenv("TF_ACC_PREVIOUS_EXEC")
-	if prevExec != "" {
-		if info, err := os.Stat(prevExec); err != nil {
-			return nil, fmt.Errorf("TF_ACC_PREVIOUS_EXEC of %s cannot be used: %s", prevExec, err)
-		} else if info.IsDir() {
-			return nil, fmt.Errorf("TF_ACC_PREVIOUS_EXEC of %s is directory, not file", prevExec)
-		}
-	}
-
-	absPluginExecPath, err := filepath.Abs(os.Args[0])
-	if err != nil {
-		return nil, fmt.Errorf("could not resolve plugin exec path %s: %s", os.Args[0], err)
-	}
-
 	return &Config{
-		PluginName:         pluginName,
-		SourceDir:          sourceDir,
-		TerraformExec:      tfExec,
-		execTempDir:        tfDir,
-		CurrentPluginExec:  absPluginExecPath,
-		PreviousPluginExec: os.Getenv("TF_ACC_PREVIOUS_EXEC"),
+		SourceDir:     sourceDir,
+		TerraformExec: tfExec,
+		execTempDir:   tfDir,
 	}, nil
 }

--- a/guard.go
+++ b/guard.go
@@ -50,22 +50,6 @@ func LongTest(t TestControl) {
 	}
 }
 
-// RequirePreviousVersion is a test guard that will produce a log and call
-// SkipNow on the given TestControl if the receiving Helper does not have a
-// previous plugin version to test against.
-//
-// Call this immediately at the start of any "upgrade test" that expects to
-// be able to run some operations with a previous version of the plugin before
-// "upgrading" to the current version under test to continue with other
-// operations.
-func (h *Helper) RequirePreviousVersion(t TestControl) {
-	t.Helper()
-	if !h.HasPreviousVersion() {
-		t.Log("no previous plugin version available")
-		t.SkipNow()
-	}
-}
-
 // TestControl is an interface requiring a subset of *testing.T which is used
 // by the test guards and helpers in this package. Most callers can simply
 // pass their *testing.T value here, but the interface allows other

--- a/helper.go
+++ b/helper.go
@@ -23,8 +23,8 @@ const subprocessPreviousSigil = "2279afb8cf71423996be1fd65d32f13b"
 // available for upgrade tests, and then will return an object containing the
 // results of that initialization which can then be stored in a global variable
 // for use in other tests.
-func AutoInitProviderHelper(name string, sourceDir string) *Helper {
-	helper, err := AutoInitHelper("terraform-provider-"+name, sourceDir)
+func AutoInitProviderHelper(sourceDir string) *Helper {
+	helper, err := AutoInitHelper(sourceDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot run Terraform provider tests: %s\n", err)
 		os.Exit(1)
@@ -40,13 +40,11 @@ type Helper struct {
 	// sourceDir is the dir containing the provider source code, needed
 	// for tests that use fixture files.
 	sourceDir     string
-	pluginName    string
 	terraformExec string
 
 	// execTempDir is created during DiscoverConfig to store any downloaded
 	// binaries
-	execTempDir                  string
-	thisPluginDir, prevPluginDir string
+	execTempDir string
 }
 
 // AutoInitHelper uses the auto-discovery behavior of DiscoverConfig to prepare
@@ -54,8 +52,8 @@ type Helper struct {
 // way to get the standard init behavior based on environment variables, and
 // callers should use this unless they have an unusual requirement that calls
 // for constructing a config in a different way.
-func AutoInitHelper(pluginName string, sourceDir string) (*Helper, error) {
-	config, err := DiscoverConfig(pluginName, sourceDir)
+func AutoInitHelper(sourceDir string) (*Helper, error) {
+	config, err := DiscoverConfig(sourceDir)
 	if err != nil {
 		return nil, err
 	}
@@ -74,55 +72,16 @@ func AutoInitHelper(pluginName string, sourceDir string) (*Helper, error) {
 // automatically clean those up.
 func InitHelper(config *Config) (*Helper, error) {
 	tempDir := os.Getenv("TF_ACC_TEMP_DIR")
-	baseDir, err := ioutil.TempDir(tempDir, "tftest-"+config.PluginName)
+	baseDir, err := ioutil.TempDir(tempDir, "tftest")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory for test helper: %s", err)
-	}
-
-	var thisPluginDir, prevPluginDir string
-	if config.CurrentPluginExec != "" {
-		thisPluginDir, err = ioutil.TempDir(baseDir, "plugins-current")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temporary directory for -plugin-dir: %s", err)
-		}
-		currentExecPath := filepath.Join(thisPluginDir, config.PluginName)
-		err = symlinkFile(config.CurrentPluginExec, currentExecPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create symlink at %s to %s: %s", currentExecPath, config.CurrentPluginExec, err)
-		}
-
-		err = symlinkAuxiliaryProviders(thisPluginDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to symlink auxiliary providers: %s", err)
-		}
-	} else {
-		return nil, fmt.Errorf("CurrentPluginExec is not set")
-	}
-	if config.PreviousPluginExec != "" {
-		prevPluginDir, err = ioutil.TempDir(baseDir, "plugins-previous")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temporary directory for previous -plugin-dir: %s", err)
-		}
-		prevExecPath := filepath.Join(prevPluginDir, config.PluginName)
-		err = symlinkFile(config.PreviousPluginExec, prevExecPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create symlink at %s to %s: %s", prevExecPath, config.PreviousPluginExec, err)
-		}
-
-		err = symlinkAuxiliaryProviders(prevPluginDir)
-		if err != nil {
-			return nil, fmt.Errorf("failed to symlink auxiliary providers: %s", err)
-		}
 	}
 
 	return &Helper{
 		baseDir:       baseDir,
 		sourceDir:     config.SourceDir,
-		pluginName:    config.PluginName,
 		terraformExec: config.TerraformExec,
 		execTempDir:   config.execTempDir,
-		thisPluginDir: thisPluginDir,
-		prevPluginDir: prevPluginDir,
 	}, nil
 }
 
@@ -201,11 +160,6 @@ func symlinkAuxiliaryProviders(pluginDir string) error {
 	return nil
 }
 
-// GetPluginName returns the configured plugin name.
-func (h *Helper) GetPluginName() string {
-	return h.pluginName
-}
-
 // Close cleans up temporary files and directories created to support this
 // helper, returning an error if any of the cleanup fails.
 //
@@ -239,12 +193,6 @@ func (h *Helper) NewWorkingDir() (*WorkingDir, error) {
 		return nil, err
 	}
 
-	// symlink the provider binaries into the base directory
-	err = symlinkDir(h.thisPluginDir, dir)
-	if err != nil {
-		return nil, err
-	}
-
 	return &WorkingDir{
 		h:        h,
 		baseArgs: []string{"-no-color"},
@@ -267,35 +215,8 @@ func (h *Helper) RequireNewWorkingDir(t TestControl) *WorkingDir {
 	return wd
 }
 
-// HasPreviousVersion returns true if and only if the receiving helper has a
-// previous plugin version available for use in tests.
-func (h *Helper) HasPreviousVersion() bool {
-	return h.prevPluginDir != ""
-}
-
 // TerraformExecPath returns the location of the Terraform CLI executable that
 // should be used when running tests.
 func (h *Helper) TerraformExecPath() string {
 	return h.terraformExec
-}
-
-// PluginDir returns the directory that should be used as the -plugin-dir when
-// running "terraform init" in order to make Terraform detect the current
-// version of the plugin.
-func (h *Helper) PluginDir() string {
-	return h.thisPluginDir
-}
-
-// PreviousPluginDir returns the directory that should be used as the -plugin-dir
-// when running "terraform init" in order to make Terraform detect the previous
-// version of the plugin, if available.
-//
-// If no previous version is available, this method will panic. Use
-// RequirePreviousVersion or HasPreviousVersion to ensure a previous version is
-// available before calling this.
-func (h *Helper) PreviousPluginDir() string {
-	if h.prevPluginDir != "" {
-		panic("PreviousPluginDir not available")
-	}
-	return h.prevPluginDir
 }

--- a/working_dir.go
+++ b/working_dir.go
@@ -141,7 +141,7 @@ func (wd *WorkingDir) RequireClearPlan(t TestControl) {
 	}
 }
 
-func (wd *WorkingDir) init(pluginDir string) error {
+func (wd *WorkingDir) init() error {
 	args := []string{"init", wd.configDir}
 	args = append(args, wd.baseArgs...)
 	return wd.runTerraform(args...)
@@ -153,7 +153,7 @@ func (wd *WorkingDir) Init() error {
 	if wd.configDir == "" {
 		return fmt.Errorf("must call SetConfig before Init")
 	}
-	return wd.init(wd.h.PluginDir())
+	return wd.init()
 }
 
 // RequireInit is a variant of Init that will fail the test via the given
@@ -161,29 +161,6 @@ func (wd *WorkingDir) Init() error {
 func (wd *WorkingDir) RequireInit(t TestControl) {
 	t.Helper()
 	if err := wd.Init(); err != nil {
-		t := testingT{t}
-		t.Fatalf("init failed: %s", err)
-	}
-}
-
-// InitPrevious runs "terraform init" for the given working directory, forcing
-// Terraform to use the previous version of the plugin under test.
-//
-// This method will panic if no previous plugin version is available. Use
-// HasPreviousVersion or RequirePreviousVersion on the test helper singleton
-// to check this first.
-func (wd *WorkingDir) InitPrevious() error {
-	if wd.configDir == "" {
-		return fmt.Errorf("must call SetConfig before InitPrevious")
-	}
-	return wd.init(wd.h.PreviousPluginDir())
-}
-
-// RequireInitPrevious is a variant of InitPrevious that will fail the test
-// via the given TestControl if init fails.
-func (wd *WorkingDir) RequireInitPrevious(t TestControl) {
-	t.Helper()
-	if err := wd.InitPrevious(); err != nil {
 		t := testingT{t}
 		t.Fatalf("init failed: %s", err)
 	}


### PR DESCRIPTION
This information is no longer required in reattach mode. This simplifies usage for reattach testing in `terraform-plugin-sdk` but is a breaking change.