### PR TITLE
working_dir: return output of function call instead of explicit error when import fails

### DIFF
--- a/working_dir.go
+++ b/working_dir.go
@@ -370,12 +370,8 @@ func (wd *WorkingDir) Import(resource, id string) error {
 
 // RequireImport is a variant of Import that will fail the test via
 // the given TestControl if the import is non successful.
-func (wd *WorkingDir) RequireImport(t TestControl, resource, id string) {
-	t.Helper()
-	if err := wd.Import(resource, id); err != nil {
-		t := testingT{t}
-		t.Fatalf("failed to import: %s", err)
-	}
+func (wd *WorkingDir) RequireImport(resource, id string) error {
+	return wd.Import(resource, id)
 }
 
 // Refresh runs terraform refresh


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-sdk/issues/532

In some provider acceptance testing, an error is expected during `Import` related steps so to account for this, we can return the output of  ` RequireImport` instead to the SDK testing framework and from there the error can be handled as either a true error or one that we expect in an acceptance test step. 